### PR TITLE
Running locally guide update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,9 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     ffi (1.9.25)
+    ffi (1.9.25-x64-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
@@ -52,7 +54,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rouge (3.2.1)
+    rouge (3.3.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
     sass (3.6.0)
@@ -60,15 +62,23 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2018.5)
+      tzinfo (>= 1.0.0)
+    wdm (0.1.1)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   jekyll (~> 3.8.4)
   jekyll-feed (~> 0.6)
   minima (~> 2.0)
   tzinfo-data
+  wdm (~> 0.1.0)
 
 BUNDLED WITH
    1.16.5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hacktobesfest Website
+# Hacktoberfest Website
 
 This website is a community website for everyone to be able to contribute to. Tech should be accessible to everyone and everyone should be included in the making of it. This site aims to help break down barriers and allow people to contribute to a project with whatever skills they have.
 

--- a/README.md
+++ b/README.md
@@ -8,20 +8,62 @@ You can contribute through the browser or from your favourite terminal. Go the [
 
 ## Getting The Site Running Locally
 
-You'll need ruby for the site to run locally. Follow the instructions [here](https://jekyllrb.com/docs/installation/) for downloading ruby and the other dependencies you'll need.
+The site is built using [Jekyll](https://jekyllrb.com), a Ruby application, or **Gem**.
 
-Check you have Ruby version 2.3.3
+As such, you'll need Ruby installed (version `2.3.3` or newer).
 
-If you haven't already, in a terminal, type:
+This guide does include steps for installing Ruby, and other Jekyll dependencies, but you can always refer to Jekyll's own guide [here](https://jekyllrb.com/docs/installation/).
 
- `$ gem install jekyll bundler`
+### Installing Ruby and other dependencies
 
-Then you should be up and running! To run the site locally, make sure you're in the project folder root and run:
+#### Windows (native)
 
-`$ bundle exec jekyll serve`.
+To install Ruby on Windows, you can
 
-Head over to your browser and go to [http://localhost:4000/](http://localhost:4000/) to view the site!
+- Use **Chocolatey** (a Windows Package Manager)
+    1. [Get Chocolatey](https://chocolatey.org)
+    1. Open Command Prompt or Powershell
+    1. `> choco install ruby -y`
+- Download it from [RubyInstaller](https://rubyinstaller.org)
+    1. Download **Ruby + Devkit**
+    1. Run the installer
 
-Well done, you're up and running!
+#### Linux / Windows Subsystem for Linux
 
-Instruction not clear? Raise a pull request with your changes.
+For Ubuntu / Debian-based distributions:
+
+`$ sudo apt install ruby ruby-dev build-essential -y`
+
+### Installing Jekyll
+
+Now that Ruby is installed, installing Jekyll (and other gems) should be platform agnostic.
+
+- you may need to run commands prefixed by `sudo` on non-Windows environments.
+- You may need to logout / restart your terminal window to refresh paths.
+
+Install **Jekyll** as follows, from a terminal window:
+
+`gem install jekyll bundler`
+
+### Install site dependencies
+
+To ensure the site has any other gems it depends on installed, make sure you're in the project folder root and run:
+
+`bundle update`
+
+### Running the site
+
+Now that everything is set up, you can run the site locally.
+
+1. Make sure you're in the project folder root and run:
+    - `jekyll serve`.
+1. Leave that terminal window open
+1. Head to your favourite web browser
+
+The local site can be reached here: [http://localhost:4000/](http://localhost:4000/)
+
+Well done, you're up and running! :tada:
+
+### Instructions not clear?
+
+Raise a pull request with your changes!

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ For Ubuntu / Debian-based distributions:
 
 Now that Ruby is installed, installing Jekyll (and other gems) should be platform agnostic.
 
-- you may need to run commands prefixed by `sudo` on non-Windows environments.
-- You may need to logout / restart your terminal window to refresh paths.
+- :information_source: you may need to run commands prefixed by `sudo` on non-Windows environments.
+- :information_source: You may need to logout / restart your terminal window to refresh paths.
 
 Install **Jekyll** as follows, from a terminal window:
 


### PR DESCRIPTION
- The guide to running the site locally has been elaborated on for #3 , with steps for getting Ruby installed on Windows, and clear steps for running the project in any environment with Ruby (hopefully).
    - (didn't add macOS guidance as I don't use it)
- Also fixed a typo in the readme.
- Also running `bundle update` caused changes to `Gemfile.lock` but I believe these are desirable updates as they include x64 Windows as a target platform for `tzinfo` gems, and `wdm` which is needed for Jekyll on Windows.