### PR TITLE
Add support for authors

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,0 +1,6 @@
+anna_dodson:
+    name: Anna Dodson
+
+will_ellwood:
+    name: Will Ellwood
+    web: http://www.will-ellwood.com

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,31 @@
+---
+layout: default
+---
+{% assign author = site.data.authors[page.author] %}
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
+    <header class="post-header">
+        <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
+        <p class="post-meta">
+            <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+                {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+                {{ page.date | date: date_format }}
+            </time>
+            {%- if author -%}
+            {%- if author.web -%}
+            • <a href="{{ author.web }}"><span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ author.name }}</span></span></a>
+            {%- else -%}
+            • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ author.name }}</span></span>
+            {%- endif -%}
+            {%- endif -%}</p>
+    </header>
+
+    <div class="post-content e-content" itemprop="articleBody">
+        {{ content }}
+    </div>
+
+    {%- if site.disqus.shortname -%}
+    {%- include disqus_comments.html -%}
+    {%- endif -%}
+
+    <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
+</article>

--- a/_posts/2018-09-30-annadodson-blog-post.markdown
+++ b/_posts/2018-09-30-annadodson-blog-post.markdown
@@ -2,6 +2,7 @@
 layout: post
 title:  "It takes a village"
 date:   2018-10-02 14:01:10 +0100
+author: anna_dodson
 categories: contributing community blog
 ---
 

--- a/_posts/2018-10-03-write-better.md
+++ b/_posts/2018-10-03-write-better.md
@@ -2,8 +2,7 @@
 layout: post
 title:  "Write Better!"
 date:   2018-10-03 10:01:10 +0100
-author: "Will Ellwood"
-author-link: "www.will-ellwood.com"
+author: will_ellwood
 categories: community contributions
 ---
 

--- a/contributing.md
+++ b/contributing.md
@@ -79,7 +79,21 @@ To add a post, create a file under the `_posts/` directory. Name the file with t
 _posts/2018-10-01-my-epic-post-title.md
 ```
 
-This is a markdown file so you can use markdown syntax. You can also add HTML tags too.
+Before writing the post, ensure your author details are added to the authors database at `_data/authors.yml`. Copy the
+block below (be sure to preserve indentation - it's important in YAML) and edit the details. The key should be in the
+format firstname_lastname with any special characters removed. The 'name' property is required, and can be enclosed in
+"quotes" if non-alphanumeric characters are included, and the 'web' property is optional, and can be used to link to
+wherever you like.
+
+The file is designed for future expansion and more details being added to the authors if required in the future.
+
+```
+ada_lovelace:
+    name: "Ada Lovelace"
+    web: https://www.github.com
+```
+
+Back to the post itself! This is a markdown file so you can use markdown syntax. You can also add HTML tags too.
 
 In the file, make sure to include all your posts details:
 
@@ -88,6 +102,7 @@ In the file, make sure to include all your posts details:
 layout: post
 title:  "My Epic Post Title"
 date:   2018-10-01 14:01:10 +0100
+author: ada_lovelace
 categories: community contributions
 ---
 ```


### PR DESCRIPTION
Support for authors on the site, with an optional web link.

Changes:
- Added authors.yml data file in _data to centralise author information
- Copy post.html template from minima theme, and adjust to display author information
- Adjust existing posts to correctly tag authors

Fixes #9