### PR TITLE
Mac OS X instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ To install Ruby on Windows, you can
     1. Download **Ruby + Devkit**
     1. Run the installer
 
+#### Mac OS X
+
+OS X comes with many open source packages pre-installed, including Ruby. To check your version of ruby, open a terminal and run `$ ruby -v`
+
+You should get some output like this, denoting version `2.3.7`:
+```
+ruby 2.3.7p456 (2018-03-28 revision 63024) [universal.x86_64-darwin17]
+```
+
+If your version is `2.3.3` or greater, you do not need to install ruby; you can move on to [Instaling Jekyll](#installing-jekyll).
+
+Otherwise, you will need to upgrade ruby. The easiest way is to use `rvm`. In the terminal, run the following commands:
+- `$ curl -sSL https://get.rvm.io | bash -s stable --ruby`
+- `$ rvm install 2.3`
+- `$ rvm use 2.3 --default`
+
+Restart your terminal and check the ruby version using `> ruby -v`
+
 #### Linux / Windows Subsystem for Linux
 
 For Ubuntu / Debian-based distributions:


### PR DESCRIPTION
Includes instructions for checking pre-installed ruby version and updating ruby using rvm.

Addresses missing Mac OS X instructions from #3 