### PR TITLE
fix: percentage grid gap causing overflow on contributors page

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -72,7 +72,7 @@ code{
     padding-bottom: 2em;
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(8em, 1fr));
-    grid-gap:5%;
+    grid-gap: 35px;
     align-items: stretch;
     justify-items: center;
     .contributor {


### PR DESCRIPTION
This PR should fix this overlapping issue:
![contriubtors overlapping footer](https://user-images.githubusercontent.com/1003034/67167012-eab1c280-f38c-11e9-89a8-32388ed4138a.png)
